### PR TITLE
[Feat] #17 킥보드 등록 정보 마이페이지에 데이터 연결

### DIFF
--- a/KickMe/KickMe/Controller/MyPageViewController.swift
+++ b/KickMe/KickMe/Controller/MyPageViewController.swift
@@ -3,9 +3,9 @@ import UIKit
 import SnapKit
 
 class MyPageViewController: UIViewController {
-    /* ---------- 테이블뷰 테스트용 임시 데이터 ---------- */
-    var usageDatas: [String] = ["2025.10.01", "2025.10.03", "2025.10.10"]
-    var kickBoardDatas: [String] = ["01번", "02번", "03번"]
+    /* ---------- 테이블뷰에 추가 될 데이터 배열 ---------- */
+    var usageDatas: [String] = []
+    var kickBoardDatas: [String] = []
     
     /* ---------- UI 요소 ---------- */
     private let myPageLabel: UILabel = {
@@ -203,5 +203,22 @@ extension MyPageViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
 }
-
+/* ---------- 등록 페이지에서 입력된 데이터 추가하는 함수 ---------- */
+extension MyPageViewController {
+    func updateData(newBoardNum: String, newTimeText: String) {
+        
+        // 이용 내역 추가
+        let now = Date()
+        let nowString = now.dateTime
+        
+        let usageEntry = "\(nowString) - \(newTimeText)"
+        usageDatas.append(usageEntry)
+        
+        // 킥보드 번호 추가
+        kickBoardDatas.append(newBoardNum)
+        
+        historyTableView.reloadData()
+        kickBoardTableView.reloadData()
+    }
+}
 

--- a/KickMe/KickMe/Controller/RegisterViewController.swift
+++ b/KickMe/KickMe/Controller/RegisterViewController.swift
@@ -1,6 +1,4 @@
 
-
-
 import Foundation
 import UIKit
 
@@ -112,6 +110,7 @@ class RegisterViewController: UIViewController {
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         toolBar.setItems([space, doneButton], animated: true)
         toolBar.isUserInteractionEnabled = true
+        
         // 텍스트필드에 툴바 연결
         timeTextField.inputAccessoryView = toolBar
 
@@ -124,7 +123,6 @@ class RegisterViewController: UIViewController {
         } else {
             timeTextField.resignFirstResponder()
         }
-
     }
     
     /* ---------- "등록하기" 버튼 클릭 시 실행 (함수이름 수정 필요)---------- */
@@ -132,6 +130,16 @@ class RegisterViewController: UIViewController {
     private func didmissModalView() {
         guard let boardNum = kickBoardTextField.text, !boardNum.isEmpty else { return }
         guard let timeText = timeTextField.text, !timeText.isEmpty else { return }
+        
+        // 이용내역 & 킥보드 번호 데이터 전달
+        if let tabBarController = self.tabBarController,
+           let viewControllers = tabBarController.viewControllers,
+           viewControllers.count > 2,
+           
+           let myPageNav = viewControllers[2] as? UINavigationController,
+           let myPageVC = myPageNav.viewControllers.first(where: { $0 is MyPageViewController }) as? MyPageViewController {
+            myPageVC.updateData(newBoardNum: boardNum, newTimeText: timeText)
+        }
 
         // 탭바 컨트롤러 연결
         guard let tabBarController = self.tabBarController else { return }
@@ -145,7 +153,6 @@ class RegisterViewController: UIViewController {
         // 버튼 누르면 텍스트필드 비워짐
         kickBoardTextField.text = ""
         timeTextField.text = ""
-
     }
 }
 

--- a/KickMe/KickMe/Models/DateExtension.swift
+++ b/KickMe/KickMe/Models/DateExtension.swift
@@ -1,0 +1,11 @@
+import Foundation
+/* ---------- 킥보드 등록시점 날짜와 시간 기록용 ---------- */
+extension Date {
+    var dateTime: String {
+        let formatter = DateFormatter()
+        
+        formatter.dateFormat = "yyyy.MM.dd HH:mm"
+        
+        return formatter.string(from: self)
+    }
+}


### PR DESCRIPTION

### 🚀 Description
> - 킥보드 등록 페이지에서 입력한 데이터를 마이페이지의 "이용 내용"과 "내가 등록한 킥보드" 각각의 테이블뷰에 데이터를 표시함
> - 이용 내역에는 "등록하기" 버튼 누른 시점의 날짜와 시간 + 대여 기간이 표시됨
> - 5줄 이상 부터는 스크롤 

### 📸 Screenshot
<img src="https://github.com/user-attachments/assets/74650ae0-7253-464b-9588-244c192e3969" width="30%">


### #️⃣ IssueNumber
#17 

### ✅ CheckList
- Merge 대상 브랜치가 올바른가? 네

- 작업한 코드가 에러 없이 잘 동작하는가? 네
