### PR TITLE
[Feat] #23 회원가입 완료 후 로그인 화면으로 돌아가기

### DIFF
--- a/KickMe/KickMe/Controller/SignUpViewController.swift
+++ b/KickMe/KickMe/Controller/SignUpViewController.swift
@@ -150,6 +150,7 @@ class SignUpViewController: UIViewController {
         signUpButton.addTarget(self, action: #selector(didTapSignUp), for: .touchUpInside)
     }
     
+    
     // 회원가입 버튼 동작
     @objc private func didTapSignUp() {
         
@@ -166,10 +167,23 @@ class SignUpViewController: UIViewController {
             present(alert, animated: true)
             return
         }
+        // 비밀번호 8자 미만일 때 경고 알림 (추가)
+        if pw.count < 8 {
+            let alert = UIAlertController(title: "비밀번호 오류", message: "비밀번호는 8자 이상 입력해주세요", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        
         
         // 모두 입력했을 때 성공 알림
         let successAlert = UIAlertController(title: "회원가입 완료", message: "회원가입이 성공적으로 완료되었습니다!", preferredStyle: .alert)
-        successAlert.addAction(UIAlertAction(title: "확인", style: .default))
+        
+        successAlert.addAction(UIAlertAction(title: "확인", style: .default, handler:  { _ in
+            // 회원가입 완료 후 로그인 화면으로 돌아가기
+            self.dismiss(animated: true)
+            self.navigationController?.popViewController(animated: true)
+        }))
         present(successAlert, animated: true)
             
         }

--- a/KickMe/KickMe/Supporting Files/SceneDelegate.swift
+++ b/KickMe/KickMe/Supporting Files/SceneDelegate.swift
@@ -10,7 +10,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
 
 
-        window.rootViewController = TabBarController()
+        window.rootViewController = LoginViewController()
 
         window.makeKeyAndVisible()
 


### PR DESCRIPTION
PR 제목에 [Feature] #이슈번호 구현내용(이슈제목과 똑같이 적어주세요)

### 🚀 Description
> 회원가입 완료 후 로그인 화면으로 돌아가게 만들었습니다. 추가로 비밀번호 8자 미만 입력 시 알림창 뜨게 설정했습니다.

### 📸 Screenshot
>
<img width="498" height="943" alt="스크린샷 2025-10-16 11 51 41" src="https://github.com/user-attachments/assets/17ec6b16-4345-4c4a-bd8f-8db747596325" />

<img width="498" height="943" alt="스크린샷 2025-10-16 11 51 52" src="https://github.com/user-attachments/assets/5d0559c6-f51e-4d52-8825-00446d21d569" />

### #️⃣ IssueNumber
#23

### ✅ CheckList
- Merge 대상 브랜치가 올바른가? 네

- 작업한 코드가 에러 없이 잘 동작하는가? 네
