### PR TITLE
[Feat] #35 마이페이지 이용 내역, 킥보드 리스트 저장/불러오기

### DIFF
--- a/KickMe/KickMe/Controller/MyPageViewController.swift
+++ b/KickMe/KickMe/Controller/MyPageViewController.swift
@@ -4,9 +4,10 @@ import SnapKit
 import KakaoMapsSDK
 
 class MyPageViewController: UIViewController {
-    /* ---------- 테이블뷰에 추가 될 데이터 배열 ---------- */
-    var usageDatas: [String] = []
-    var kickBoardDatas: [String] = []
+    // CoreData에서 가져온 이용 내역
+    private var rentalHistory: [RentalRecord] = []
+    // 킥보드 번호
+    var kickBoarDatas: [String] = []
     
     /* ---------- UI 요소 ---------- */
     private let myPageLabel: UILabel = {
@@ -94,6 +95,16 @@ class MyPageViewController: UIViewController {
         setConstraints()
 
     }
+    /* ---------- CoreData 최신 데이터 불러오기 ---------- */
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadHistoryData()
+        historyTableView.reloadData()
+        kickBoardTableView.reloadData()
+        updateUseOrNot()
+
+    }
+    
     /* ---------- UI 구성 ---------- */
     func configureUI() {
         view.backgroundColor = .white
@@ -170,61 +181,80 @@ class MyPageViewController: UIViewController {
         signOutAlrert()
     }
 }
+/* ---------- Core 데이터 관련 ---------- */
+extension MyPageViewController {
+    // 데이터 로드
+    private func loadHistoryData() {
+        rentalHistory = CoreDataManager.shared.fetchAllRentHistory()
+        kickBoarDatas = rentalHistory.map { $0.boardNum }
+        let kickBoardDatas = kickBoarDatas
+        print("현재 kickBoardDatas 개수: \(kickBoardDatas.count)")
+    }
+    // 대여 상태 레이블 업데이트
+    private func updateUseOrNot() {
+        let isRented = CoreDataManager.shared.isCurrentlyRented()
+        useOrNotLabel.text = isRented ? "대여 중" : "대여 가능"
+        useOrNotLabel.textColor = isRented ? UIColor(named: "MainColor") : .gray
+    }
+}
+/* ---------- 킥보드 테이블뷰 업데이트 ---------- */
+extension MyPageViewController {
+    func updateBordNum() {
+        loadHistoryData()
+        kickBoardTableView.reloadData()
+    }
+}
 
 /* ---------- 이용내역/등록한 킥보드 테이블 뷰 관련 ---------- */
 extension MyPageViewController: UITableViewDelegate, UITableViewDataSource {
     // 셀 높이 설정
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-            40
-        }
+        40
+    }
     /* ---------- 각 테이블 뷰의 행 개수 ---------- */
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView == historyTableView {
-            return usageDatas.count
+            return rentalHistory.count
         } else if tableView == kickBoardTableView {
-            return kickBoardDatas.count
+            return kickBoarDatas.count
         }
         return 0
     }
     /* ---------- 각 테이블 뷰 셀 데이터 연결 ---------- */
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // 이용 내역 테이블뷰 데이터
+        let record = rentalHistory[indexPath.row]
+        
         if tableView == historyTableView {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.id, for: indexPath) as?    HistoryTableViewCell else {
                 return UITableViewCell()
             }
-            let usageData = usageDatas[indexPath.row]
+            // 대여 중 / 반납 완료 시 이용 내역 분기
+            
+            let duration = record.rentalTime
+            
+            let usageText = record.isReturned ? "이용 종료" : "이용 중"
+            
+            let usageData = "\(record.startTime) / \(duration) / \(usageText)"
+            
             cell.configureCell(with: usageData)
             return cell
+            
+        // 킥보드 번호 테이블뷰 데이터
         } else if tableView == kickBoardTableView {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: KickBoardTableViewCell.id, for: indexPath) as?    KickBoardTableViewCell else {
                 return UITableViewCell()
             }
-            let kickBoardData = kickBoardDatas[indexPath.row]
-            cell.configureCell(with: kickBoardData)
+            
+            let boardData = kickBoarDatas[indexPath.row]
+            cell.configureCell(with: boardData)
             return cell
         }
+               
         return UITableViewCell()
     }
-    
 }
-/* ---------- 등록 페이지에서 입력된 데이터 추가하는 함수 ---------- */
-extension MyPageViewController {
-    func updateData(newBoardNum: String, newTimeText: String) {
-        
-        // 이용 내역 추가
-        let now = Date()
-        let nowString = now.dateTime
-        
-        let usageEntry = "\(nowString) - \(newTimeText)"
-        usageDatas.append(usageEntry)
-        
-        // 킥보드 번호 추가
-        kickBoardDatas.append(newBoardNum)
-        
-        historyTableView.reloadData()
-        kickBoardTableView.reloadData()
-    }
-}
+
 /* ---------- 알럿기능 추가 ---------- */
 extension MyPageViewController {
     func makeAlert(title: String,

--- a/KickMe/KickMe/Controller/RegisterViewController.swift
+++ b/KickMe/KickMe/Controller/RegisterViewController.swift
@@ -143,15 +143,15 @@ class RegisterViewController: UIViewController {
             tabBarController.changeMainButton(to: "반납")
         }
         
-        // 이용내역 & 킥보드 번호 데이터 전달
+        // 킥보드 번호 데이터 전달
         if let tabBarController = self.tabBarController,
            let viewControllers = tabBarController.viewControllers,
            viewControllers.count > 2,
            
            let myPageNav = viewControllers[2] as? UINavigationController,
            let myPageVC = myPageNav.viewControllers.first(where: { $0 is MyPageViewController }) as? MyPageViewController {
-            myPageVC.updateData(newBoardNum: boardNum, newTimeText: timeText)
-        }
+            myPageVC.updateBordNum()
+           }
 
         // 버튼 누르면 텍스트필드 비워짐
         kickBoardTextField.text = ""

--- a/KickMe/KickMe/Controller/TabBarController.swift
+++ b/KickMe/KickMe/Controller/TabBarController.swift
@@ -43,7 +43,7 @@ class TabBarController: UITabBarController {
         
         if isRented {
             CoreDataManager.shared.completeRental()
-            
+
             self.changeMainButton(to: "대여")
             selectedIndex = 0
             (viewControllers?[0] as? UINavigationController)?

--- a/KickMe/KickMe/CoreData/CoreDataManager.swift
+++ b/KickMe/KickMe/CoreData/CoreDataManager.swift
@@ -28,7 +28,7 @@ class CoreDataManager {
         // 저장
         do {
             try context.save()
-            print("대여 기록 저장 성공.\(newRental.startTime ?? "저장 실패")")
+            print("대여 기록 저장 성공.\(newRental.startTime ?? "저장 실패"), \(boardNum)")
         } catch {
             print("대여 기록 저장 실패 \(error)")
         }
@@ -44,7 +44,6 @@ class CoreDataManager {
                 return
             }
             
-            rentalToUpdate.rentalTime = String()
             rentalToUpdate.isReturned = true
             
             try context.save()


### PR DESCRIPTION
PR 제목에 [Feature] #이슈번호 구현내용(이슈제목과 똑같이 적어주세요)

### 🚀 Description
> 마이페이지 이용내역, 킥보드 리스트 저장/불러오기(앱을 재실행해도 데이터 남아있음
> 대여 상태 표시 레이블 "대여 중" / "대여 가능" 으로 표시

### 📸 Screenshot
>UI 관련 작업이 포함되었을 경우 스크린샷 또는 동영상 첨부 부탁드립니다!
![#35](https://github.com/user-attachments/assets/556a4d6e-eb58-49ee-b1fa-1180bf9e810a)


### #️⃣ IssueNumber
#35 

### ✅ CheckList
- Merge 대상 브랜치가 올바른가? 네

- 작업한 코드가 에러 없이 잘 동작하는가? 네
